### PR TITLE
Fix 'git checkout' pulling from incorrect branch in 'install_sh.sh' s…

### DIFF
--- a/install_sh.sh
+++ b/install_sh.sh
@@ -119,7 +119,7 @@ if [ ! -d "$DOCKER_CONTEXT" ]; then
   # NB: this is to make onprem containers to all get named the same.
   cd self-hosted
   if ! command_present unzip; then
-    git checkout master # TODO(hirday): delete this.
+    git checkout main # TODO(hirday): delete this.
   fi
   DOCKER_CONTEXT="$(pwd)"
 


### PR DESCRIPTION
The install script attempts to checkout the 'master' branch. However this (I assume) has been renamed to 'main'.